### PR TITLE
Add option to delay triggerOnInsert onto the next ember run loop

### DIFF
--- a/addon/mixins/scroll-handler.js
+++ b/addon/mixins/scroll-handler.js
@@ -20,6 +20,9 @@ export default Ember.Mixin.create({
   // Whether to trigger the scroll handler on initial insert
   triggerOnInsert: false,
 
+  // Whether to trigger the scroll handler on next run loop
+  delayTriggerOnInsert: false,
+
   // Setups up the handler binding for the scroll function
   registerScrollHandlers: Ember.on('didInsertElement', function() {
     // TODO: limit this to the views object (this.$()) or the window
@@ -36,7 +39,13 @@ export default Ember.Mixin.create({
     this._scrollHandlerRegistered = true;
 
     if (this.get('triggerOnInsert')) {
-      Ember.run.scheduleOnce('afterRender', scroll);
+      if (this.get('delayTriggerOnInsert')) {
+        Ember.run.next(() => {
+          scroll();
+        });
+      } else {
+        Ember.run.scheduleOnce('afterRender', scroll);
+      }
     }
   }),
 

--- a/tests/unit/addon/mixins/scroll-handler-test.js
+++ b/tests/unit/addon/mixins/scroll-handler-test.js
@@ -89,6 +89,23 @@ test('registerScrollHandlers triggers an initial scroll with triggerOnInsert', f
   subject.unregisterScrollHandlers();
 });
 
+test('registerScrollHandlers triggers an initial scroll with triggerOnInsert and delayTriggerOnInsert', function(assert) {
+  let scrollSpy = sandbox.spy();
+
+  subject = ScrollHandlerObject.create({
+    triggerOnInsert: true,
+    delayTriggerOnInsert: true,
+    scroll: scrollSpy
+  });
+
+  Ember.run(() => subject.registerScrollHandlers());
+
+  Ember.run.next(() => assert.ok(scrollSpy.calledOnce));
+
+  subject.unregisterScrollHandlers();
+});
+
+
 /* unregisterScrollHandlers */
 
 test('unregisterScrollHandlers unbinds the scroll function on the default target', function(assert) {


### PR DESCRIPTION
If rendering happens in the afterRender queue (ex: occlusion culling based on if the content is in viewport), it is better to delay the trigger onto the next run loop so that we are guaranteed to have a rendering done so that we can more accurately decide if scroll is needed.