### PR TITLE
Add ember-cli-babel to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "1.13.14",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -48,6 +47,7 @@
     "resize"
   ],
   "dependencies": {
+    "ember-cli-babel": "^5.1.5",
     "ember-singularity": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Fixes a deprecation in ember-cli.