### PR TITLE
bumped ember-singularity to 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3055,9 +3055,9 @@
       }
     },
     "ember-singularity": {
-      "version": "1.0.3",
-      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ember-singularity/-/ember-singularity-1.0.3.tgz",
-      "integrity": "sha1-Lm2+0TXo8uYJyAeDc+p+aKV3swQ=",
+      "version": "1.0.4",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ember-singularity/-/ember-singularity-1.0.4.tgz",
+      "integrity": "sha1-ny9gq+r7eTE52g4FZVp1toco6U0=",
       "requires": {
         "ember-cli-babel": "6.9.2"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-singularity": "^1.0.3"
+    "ember-singularity": "^1.0.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
ember-singularity v1.0.4 contains a fix for an existing issue around run.throttle usage. v1.0.3 and earlier wasn't using run.throttle correctly as it was using an anonymous function as the throttled method, so there was never a handle to the throttled method. This not only makes throttling impossible, but leads to more timers needing to be cleaned up