### PR TITLE
Add `eventInterval` property for resize and scroll handler

### DIFF
--- a/addon/mixins/resize-handler.js
+++ b/addon/mixins/resize-handler.js
@@ -15,13 +15,17 @@ export default Ember.Mixin.create({
   // Determines if we should fire a resize event on element insertion
   resizeOnInsert: true,
 
+  // Interval in milliseconds at which the resize handler will be called
+  // `undefined` by default, can be overridden if custom interval is needed
+  resizeEventInterval: undefined,
+
   // Setups up the handler binding for the resize function
   registerResizeHandlers: Ember.on('didInsertElement', function() {
     // Bind 'this' context to the resize handler for when passed as a callback
     let resize = this.get(RESIZE).bind(this);
     this.set(RESIZE, resize);
 
-    this.get('unifiedEventHandler').register('window', RESIZE, resize);
+    this.get('unifiedEventHandler').register('window', RESIZE, resize, this.get('resizeEventInterval'));
 
     this._resizeHandlerRegistered = true;
 

--- a/addon/mixins/scroll-handler.js
+++ b/addon/mixins/scroll-handler.js
@@ -17,6 +17,10 @@ export default Ember.Mixin.create({
   // The hook for your scroll functionality, you must implement this
   [SCROLL]: undefined,
 
+  // Interval in milliseconds at which the scroll handler will be called
+  // `undefined` by default, can be overridden if custom interval is needed
+  scrollEventInterval: undefined,
+
   // Whether to trigger the scroll handler on initial insert
   triggerOnInsert: false,
 
@@ -31,7 +35,7 @@ export default Ember.Mixin.create({
     // Save the newly bound function back as a reference for deregistration.
     this.set(SCROLL, scroll);
 
-    this.get('unifiedEventHandler').register(eventTarget, SCROLL, scroll);
+    this.get('unifiedEventHandler').register(eventTarget, SCROLL, scroll, this.get('scrollEventInterval'));
 
     this._scrollHandlerRegistered = true;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-singularity-mixins",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-singularity": "^1.0.4"
+    "ember-singularity": "^1.2.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/unit/addon/mixins/resize-handler-test.js
+++ b/tests/unit/addon/mixins/resize-handler-test.js
@@ -96,3 +96,32 @@ test('unregisterResizeHandlers can be called more than once without erring', fun
   subject.unregisterResizeHandlers();
   subject.unregisterResizeHandlers();
 });
+
+
+test('resizeEventInterval is passed to the unified event handler service', function(assert) {
+  assert.expect(1);
+
+  let resizeEventInterval = 10;
+
+  let uehServiceRegisterStub = sandbox.stub();
+  let uehServiceUnRegisterStub = sandbox.stub();
+  let unifiedEventHandlerService = {
+    register: uehServiceRegisterStub,
+    unregister: uehServiceUnRegisterStub
+  };
+
+  subject = ResizeHandlerObject.create({
+    resizeEventInterval,
+    resize: () => {},
+    unifiedEventHandler: unifiedEventHandlerService
+  });
+
+  Ember.run(() => {
+    subject.registerResizeHandlers();
+    subject.unregisterResizeHandlers();
+  });
+
+  window.dispatchEvent(new CustomEvent('resize'));
+
+  assert.ok(uehServiceRegisterStub.calledWithExactly(sinon.match.any, sinon.match.any, sinon.match.any, resizeEventInterval));
+});

--- a/tests/unit/addon/mixins/scroll-handler-test.js
+++ b/tests/unit/addon/mixins/scroll-handler-test.js
@@ -143,3 +143,29 @@ test('unregisterScrollHandlers can be called more than once without erring', fun
   subject.unregisterScrollHandlers();
   subject.unregisterScrollHandlers();
 });
+
+test('scrollEventInterval is passed to the unified event handler service', function(assert) {
+  assert.expect(1);
+
+  let scrollEventInterval = 10;
+
+  let uehServiceRegisterStub = sandbox.stub();
+  let uehServiceUnRegisterStub = sandbox.stub();
+  let unifiedEventHandlerService = {
+    register: uehServiceRegisterStub,
+    unregister: uehServiceUnRegisterStub
+  };
+
+  subject = ScrollHandlerObject.create({
+    scrollEventInterval,
+    scroll: () => {},
+    unifiedEventHandler: unifiedEventHandlerService
+  });
+
+  subject.registerScrollHandlers();
+  subject.unregisterScrollHandlers();
+
+  window.dispatchEvent(new CustomEvent('resize'));
+
+  assert.ok(uehServiceRegisterStub.calledWithExactly(sinon.match.any, sinon.match.any, sinon.match.any, scrollEventInterval));
+});


### PR DESCRIPTION
The unified event handler service now accepts additional parameter to configure the event interval with trentmwillis/ember-singularity#25
With this change we are adding a property to mixins which can be overriden in the application if needed