### PR TITLE
update babel to latest version to avoid babel 5.x deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "resize"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
+    "ember-cli-babel": "^6.12.0",
     "ember-singularity": "^1.0.4"
   },
   "ember-addon": {


### PR DESCRIPTION
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: project -> ember-truncate -> ember-singularity-mixins -> ember-cli-babel